### PR TITLE
Adds 'placeholder' tags for BulkInsert

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -1,6 +1,11 @@
 package qb
 
-const mysqlMaxPlaceholders = 65536
+import "fmt"
+
+const (
+	mysqlMaxPlaceholders = 65536
+	defaultPlaceholder   = "?"
+)
 
 type e int
 
@@ -22,9 +27,10 @@ var errors = map[e]string{
 
 // Definition define value, column name and statement type for table columns
 type Definition struct {
-	Value    interface{}
-	Column   string
-	Operator Operator
+	Value       interface{}
+	Column      string
+	Operator    Operator
+	Placeholder string
 }
 
 // ColStatement define which sql statement will each column use
@@ -63,6 +69,32 @@ func (t Operator) String() string {
 		return ""
 	default:
 		return "= ?"
+	}
+}
+
+func (t Operator) WithPlaceholder(placeholder string) string {
+	if len(placeholder) == 0 {
+		placeholder = defaultPlaceholder
+	}
+	switch t {
+	case Equals:
+		return fmt.Sprintf("= %s", placeholder)
+	case NotEquals:
+		return fmt.Sprintf("!= %s", placeholder)
+	case Like:
+		return fmt.Sprintf("like %s", placeholder)
+	case Between:
+		return "between"
+	case Greater:
+		return fmt.Sprintf(">= %s", placeholder)
+	case Lesser:
+		return fmt.Sprintf("<= %s", placeholder)
+	case In:
+		return fmt.Sprintf("in (%s)", placeholder)
+	case Or:
+		return ""
+	default:
+		return fmt.Sprintf("= %s", placeholder)
 	}
 }
 

--- a/qb.go
+++ b/qb.go
@@ -116,7 +116,7 @@ func QueryBuilder(query string, definition []Definition) (string, []interface{})
 				requestArgs = append(requestArgs, p.Value)
 			}
 
-			column, op := buildOperator(p.Column, p.Operator, counter)
+			column, op := buildOperator(p.Column, p.Operator, counter, p.Placeholder)
 			tableArgs = append(tableArgs, tableArg{value: column, operator: op})
 		}
 	}

--- a/qb_test.go
+++ b/qb_test.go
@@ -3,7 +3,12 @@ package qb
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/google/uuid"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 func TestQueryBuilder(t *testing.T) {
@@ -39,11 +44,76 @@ func createRequest(size int) []interface{} {
 
 func TestBulkInsert(t *testing.T) {
 
-	request := createRequest(500000) // create dummy request with large data set
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	size := 500000
+	request := createRequest(size) // create dummy request with large data set
+
+	// find out how many batches will be created
+	instance := reflect.TypeOf(request[0])
+	fCount := instance.NumField()
+	maxBatchSize := int(mysqlMaxPlaceholders / fCount)
+	if size > maxBatchSize {
+		size = findBatchSize(size, maxBatchSize)
+	}
+	chunks := ChunkIt(request, size)
+
+	for i := 0; i < len(chunks); i++ {
+		mock.ExpectExec(escape(query)).WillReturnResult(sqlmock.NewResult(0, int64(size)))
+	}
 
 	ctx := context.WithValue(context.Background(), "grah", "kupus")
 
-	err := BulkInsert(ctx, query, request, nil)
+	err = BulkInsert(ctx, query, request, db)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestBulkInsertWithCustomPlaceholder(t *testing.T) {
+
+	type testStruct struct {
+		Id    string
+		Name  string `qb:"placeholder:uuid_to_bin(?,true)"`
+		Value string `qb:"placeholder:uuid_to_bin(?,true)"`
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	size := 10000
+
+	createRequest := func(size int) []interface{} {
+		result := make([]interface{}, size)
+		for i := 0; i < size; i++ {
+			result[i] = testStruct{Id: uuid.New().String(), Name: "a", Value: "haha"}
+		}
+		return result
+	}
+
+	request := createRequest(size) // create dummy request with large dataset
+
+	// find out how many batches will be created
+	instance := reflect.TypeOf(request[0])
+	fCount := instance.NumField()
+	maxBatchSize := int(mysqlMaxPlaceholders / fCount)
+	if size > maxBatchSize {
+		size = findBatchSize(size, maxBatchSize)
+	}
+	chunks := ChunkIt(request, size)
+
+	for i := 0; i < len(chunks); i++ {
+		mock.ExpectExec(escape(query)).WillReturnResult(sqlmock.NewResult(0, int64(size)))
+	}
+
+	ctx := context.WithValue(context.Background(), "grah", "kupus")
+
+	err = BulkInsert(ctx, query, request, db)
 	if err != nil {
 		panic(err)
 	}
@@ -59,4 +129,11 @@ func TestCreateStatement(t *testing.T) {
 	}
 	fmt.Println(statement)
 	fmt.Println(args)
+}
+func escape(query string) string {
+	chars := []string{`(`, `)`, `$`, `+`, `?`, `.`}
+	for _, r := range chars {
+		query = strings.Replace(query, r, `\`+r, -1)
+	}
+	return query
 }

--- a/qb_test.go
+++ b/qb_test.go
@@ -16,7 +16,7 @@ func TestQueryBuilder(t *testing.T) {
 	query := "select u.id, u.name, u.email, u.registered, u.active_from from user u"
 
 	request := []Definition{
-		{[]string{"John", "Milkovocih", "Pimpek"}, "u.name", In},
+		{Value: []string{"John", "Milkovocih", "Pimpek"}, Column: "u.name", Operator: In},
 	}
 
 	result, args := QueryBuilder(query, request)
@@ -130,6 +130,31 @@ func TestCreateStatement(t *testing.T) {
 	fmt.Println(statement)
 	fmt.Println(args)
 }
+
+func TestQueryBuilderWithPlaceholder(t *testing.T) {
+
+	query := "select u.id, u.name, u.email, u.registered, u.active_from from user u"
+
+	request := []Definition{
+		{Value: []string{"John", "Milkovocih", "Pimpek"}, Column: "u.name", Operator: In, Placeholder: "uuid_to_bin(?,true)"},
+	}
+
+	result, args := QueryBuilder(query, request)
+
+	fmt.Println(result)
+	fmt.Println(args)
+
+	request = []Definition{
+		{Value: "John", Column: "u.name", Operator: Equals, Placeholder: "uuid_to_bin(?,true)"},
+		{Value: "john@mil.com", Column: "u.email", Operator: Equals, Placeholder: "uuid_to_bin(?,true)"},
+		{Value: "reg", Column: "u.registered", Operator: Equals},
+	}
+	result, args = QueryBuilder(query, request)
+
+	fmt.Println(result)
+	fmt.Println(args)
+}
+
 func escape(query string) string {
 	chars := []string{`(`, `)`, `$`, `+`, `?`, `.`}
 	for _, r := range chars {


### PR DESCRIPTION
Allows for bulk insert to have custom placeholder tags based on struct.
Can be used if some wrapper function needs to be executed on insert
param